### PR TITLE
binarypath based on "whereis" shell command

### DIFF
--- a/megaclisas-status
+++ b/megaclisas-status
@@ -3,8 +3,9 @@
 import os
 import re
 import sys
+from subprocess import Popen, PIPE
 
-binarypath = "/usr/bin/megacli"
+binarypath = Popen(["whereis", "megacli"], stdout=PIPE).communicate()[0]
 
 # Adding a quick check to see if we're root, because on most cards I've tried this on
 # We need root access to query


### PR DESCRIPTION
Dear npinto,

i've modified the fix binarypath to use the whereis command to find where the binary is.

Update: oops, i have to fix this. Please not merge this.
